### PR TITLE
added nocontext var to locales

### DIFF
--- a/frontend/src/entities/PowerGrid/CAB/Context.vue
+++ b/frontend/src/entities/PowerGrid/CAB/Context.vue
@@ -2,7 +2,7 @@
   <Context :tabs="[$t('cab.tab.context')]">
     <template v-if="appStore.tab.context === 0">
       <img v-if="context" :src="`data:image/png;base64, ${context}`" class="cab-context-topology" />
-      <h1 v-else>Pas de contexte</h1>
+      <h1 v-else>{{  $t('cab.tab.nocontext') }}</h1>
     </template>
     <Notification
       :card="appStore.card('PowerGrid')"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -34,6 +34,7 @@
   "cab.status.notifications": "Notifications",
   "cab.status.requests": "Requests",
   "cab.tab.context": "Context",
+  "cab.tab.nocontext": "No context available",
   "cab.tab.dependencies": "Dependencies",
   "cab.tab.graph": "Graph",
   "cab.tab.map": "Map",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -34,6 +34,7 @@
   "cab.status.notifications": "Notifications",
   "cab.status.requests": "Requêtes",
   "cab.tab.context": "Contexte",
+  "cab.tab.nocontext": "Aucun contexte disponible",
   "cab.tab.graph": "Graphe",
   "cab.tab.map": "Carte",
   "cab.tab.network": "Réseau",


### PR DESCRIPTION
quick language fix for the text displayed when no context is present on powergrid usecase